### PR TITLE
Fix CIFAR-10 example config paths

### DIFF
--- a/examples/SL/image_classification/python_files/run_cifar10_glister.py
+++ b/examples/SL/image_classification/python_files/run_cifar10_glister.py
@@ -4,11 +4,15 @@ run it with default arguments using the configuration files provided in CORDS.
 """
 
 
+from pathlib import Path
 from train_sl import TrainClassifier
 from cords.utils.config_utils import load_config_data
 
-#CORDS comes with some predefined configuration files that mentiones the format of 
-config_file = "configs/SL/config_glister-warm_cifar10.py"
+# Resolve the configuration path relative to this file
+BASE_DIR = Path(__file__).resolve().parents[4]
+config_file = BASE_DIR / "configs" / "SL" / "config_glister-warm_cifar10.py"
+
+#CORDS comes with some predefined configuration files that mention the format
 #config_file = "configs/SL/config_glister_boston.py"
 #config_file = "configs/SL/config_full_boston.py"
 

--- a/examples/SL/image_classification/python_files/run_cifar10_gradmatch.py
+++ b/examples/SL/image_classification/python_files/run_cifar10_gradmatch.py
@@ -5,13 +5,16 @@ learning training loop provided in CORDS and loads the predefined
 configuration for GradMatch.
 """
 
+from pathlib import Path
 from train_sl import TrainClassifier
 from cords.utils.config_utils import load_config_data
+
+BASE_DIR = Path(__file__).resolve().parents[4]
+config_file = BASE_DIR / "configs" / "SL" / "config_gradmatch_cifar10.py"
 
 
 def main():
     # Path to the predefined configuration for GradMatch on CIFAR-10
-    config_file = "configs/SL/config_gradmatch_cifar10.py"
     config_data = load_config_data(config_file)
 
     classifier = TrainClassifier(config_data)


### PR DESCRIPTION
## Summary
- resolve configuration paths relative to file location in CIFAR-10 examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515cf35004832f8ac98936e6715877